### PR TITLE
Integrate rework-npm & more flexibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@
 var path = require("path")
   , minimatch = require("minimatch")
   , myth = require("myth")
+  , rework      = require('myth/node_modules/rework')
+  , reworkNPM = require('rework-npm')
 
 module.exports = function (options) {
   options = options || {}
@@ -15,7 +17,10 @@ module.exports = function (options) {
 
       options.source = path.join(metalsmith.source(), file)
 
-      var css = myth(files[file].contents.toString(), options)
+      var css = rework(files[file].contents.toString(), options.rework || {})
+                  .use(reworkNPM(options.reworkNpm || {}))
+                  .use(myth(options))
+                  .toString()
 
       files[file].contents = new Buffer(css)
     })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/kasperisager/metalsmith-myth",
   "dependencies": {
     "minimatch": "^2.0.4",
-    "myth": "^1.4.0"
+    "myth": "^1.4.0",
+    "rework-npm": "^1.0.0"
   }
 }


### PR DESCRIPTION
I needed to have `rework-npm` to use `@import css-stuff-from-nodemodules-npm`

May be a bit out of scope